### PR TITLE
[Feature] Loading spinner가 항상 보이도록 수정

### DIFF
--- a/customHooks/useScroll/index.js
+++ b/customHooks/useScroll/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const useScroll = () => {
+const useScroll = offsetHeight => {
   if (typeof window === 'undefined') return [];
   const [isEnd, setIsEnd] = useState(false);
 
@@ -11,7 +11,8 @@ const useScroll = () => {
         scrollTop,
         clientHeight,
       } = document.documentElement;
-      if (scrollTop + clientHeight >= scrollHeight - 10) setIsEnd(true);
+      if (scrollTop + clientHeight >= scrollHeight - offsetHeight)
+        setIsEnd(true);
       else setIsEnd(false);
     };
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,8 @@ import useScroll from '../customHooks/useScroll';
 import useLoading from '../customHooks/useLoading';
 import CommentList from '../components/commentList';
 
+const LOADING_SPINNER_HEIGHT = 100;
+
 const Home = props => {
   const { ssSuccess, ssNewsList, ssPage, ssTotalPage } = props;
 
@@ -16,8 +18,8 @@ const Home = props => {
   const [page, setPage] = useState(ssPage);
   const [totalPage, setTotalPage] = useState(ssTotalPage);
 
-  const [isEnd] = useScroll();
-  const [newsListFetch, stateNewsListLoading] = useLoading(getNewsList);
+  const [isEnd] = useScroll(LOADING_SPINNER_HEIGHT);
+  const [newsListFetch] = useLoading(getNewsList);
 
   useEffect(async () => {
     if (isEnd && page < totalPage) {
@@ -61,7 +63,7 @@ const Home = props => {
           content={news.newsContent}
         />
       ))}
-      {stateNewsListLoading && <LoadingSpinner />}
+      {!(page === totalPage) && <LoadingSpinner />}
       <CommentList commentList={commentList} />
     </>
   );


### PR DESCRIPTION
issue: #63

useScroll hooks에 offset height를 추가해서 loading spinner가 보이기 직전까지 scroll이 도달하면 fetch를 하고, 마지막 페이지에 도달하면 loading spinner를 숨긴다.